### PR TITLE
Update driver.compose.json

### DIFF
--- a/drivers/ZW_Dimmer_Rotary/driver.compose.json
+++ b/drivers/ZW_Dimmer_Rotary/driver.compose.json
@@ -30,7 +30,7 @@
     "small": "{{driverAssetsPath}}/images/small.png"
   },
   "zwave": {
-    "manufacturerId": 1080,
+    "manufacturerId": [1080,1073],
     "productTypeId": [
       514
     ],


### PR DESCRIPTION
Added ManufacturerID 1073 (HZC-Electric) as many Namron z-wave Rotary dimmer are sold with this wrong ID.